### PR TITLE
Ignore generated macroid

### DIFF
--- a/confluence/resource_content.go
+++ b/confluence/resource_content.go
@@ -2,6 +2,7 @@ package confluence
 
 import (
 	"strings"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -156,7 +157,16 @@ func updateResourceDataFromContent(d *schema.ResourceData, content *Content, cli
 // are some whitespace differences between the old and new. This supresses the
 // false differences by comparing the trimmed strings
 func resourceContentDiffBody(k, old, new string, d *schema.ResourceData) bool {
-	return strings.TrimSpace(old) == strings.TrimSpace(new)
+	old = strings.TrimSpace(old)
+	new = strings.TrimSpace(new)
+
+
+	// Ignore macro-id which changes on page update
+	reg := regexp.MustCompile(` *ac:macro-id="[\w\d\-]*" *`)
+	old = reg.ReplaceAllString(old, "${1}")
+	new = reg.ReplaceAllString(new, "${1}")
+	return old == new
+
 }
 
 // If the parent was not set, running diff will show the actual value for old and


### PR DESCRIPTION
On on premise confluence 6.7.1, macro id is generate each time the page is updated leading to inconsistent diff. Reimporting the macroid on the terraform side after the first generation is not enough. 

May be related to https://community.developer.atlassian.com/t/confluence-macro-id-is-always-different-in-execute/29253

```
- <ac:structured-macro ac:name="code" ac:schema-version="1" ac:macro-id="82cc2f42-75d2-43c4-90f6-19adf61fbae4"><ac:plain-text-body><![CDATA[
+ <ac:structured-macro ac:name="code" ac:schema-version="1"><ac:plain-text-body><![CDATA[ 
```

This proposition remove the ac:macro-id="*" from the comparison. 