### PR TITLE
Fix release workflow: pin GoReleaser to v1 and use --clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,11 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v4.2.0
         with:
-          version: latest
-          args: release --rm-dist
+          # Pin GoReleaser to v1: the .goreleaser.yml is v1-format (no
+          # `version: 2`). v1 supports `--clean` (the replacement for the
+          # removed `--rm-dist`).
+          version: "~> v1"
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically


### PR DESCRIPTION
## Summary

The `v0.3.0` release failed with:

```
⨯ command failed  error=unknown flag: --rm-dist
```

`goreleaser-action`'s `version: latest` installs GoReleaser **v2**, which **removed `--rm-dist`** (replaced by `--clean`) and requires a `version: 2` config. The repo's `.goreleaser.yml` is **v1-format**.

**Minimal fix:** pin GoReleaser to **`~> v1`** and use **`--clean`**. The action SHA pins are left exactly as-is (they were already pinned and working) — only the GoReleaser `version` constraint and `args` change. This keeps the existing v1 `.goreleaser.yml` working and avoids un-pinning any third-party actions.

## ⚠️ To actually release v0.3.0
The failed run used the workflow as it existed *at the `v0.3.0` tag*, so merging this won't retroactively fix that run. After merge, re-point the tag:

```bash
git tag -d v0.3.0 && git push origin :refs/tags/v0.3.0
git tag v0.3.0 <new master HEAD> && git push origin v0.3.0   # or cut v0.3.1
```

(The release workflow only runs on tags, so this PR's checks don't exercise GoReleaser — the retag is the real validation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)